### PR TITLE
Get class to add in options table

### DIFF
--- a/wp-content/themes/epfl/header.php
+++ b/wp-content/themes/epfl/header.php
@@ -28,7 +28,7 @@
 <?php wp_head(); ?>
 </head>
 
-<body <?php body_class(); ?>>
+<body <?php body_class(get_option('epfl:theme_faculty', '')); ?>>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'epfl' ); ?></a>
 


### PR DESCRIPTION
Le nom de la faculté (= de la classe) à ajouter est récupérée dans la base de données (option `epfl:theme_faculty`) et elle est mise en paramètre à la fonction `body_class()` qui était déjà appelée pour renvoyer les classes à ajouter à la balise `<body>`. Ceci a pour effet d'ajouter cette classe à la liste de celles qui sont déjà existantes et elle est directement mise dans le thème.
Si l'option n'existe pas dans la base de données, c'est une chaine vide qui est renvoyée et donc on n'ajoute rien.

La modification est mineure donc une PR n'était pas forcément nécessaire... je te laisse la valider si c'est OK pour toi et je la merge après.

Une fois que c'est mergé et que tu as récupéré le code, pour tester, tu peux simplement modifier le code `get_option('epfl:theme_faculty', '')` en mettant le nom de la faculté à tester en paramètre par défaut, ex:
`get_option('epfl:theme_faculty', 'enac')`. Comme ça, pas besoin que l'option soit présente dans la base de données, c'est l'option par défaut qui sera renvoyée.